### PR TITLE
Added svg template decorator. Fixes #62

### DIFF
--- a/config/config.base.js
+++ b/config/config.base.js
@@ -17,5 +17,8 @@ config.client.defaultConnectionRouter = 'basic';
 config.plugin.allowServerExecution = true;
 config.seedProjects.defaultProject = 'Caffe';
 
+config.visualization.svgDirs = ['src/svgs'];
+config.client.usedDecorators.push('SVGTemplateDecorator');
+
 validateConfig(config);
 module.exports = config;

--- a/config/config.dev.js
+++ b/config/config.dev.js
@@ -4,8 +4,5 @@
 var config = require('./config.base.js'),
     validateConfig = require('webgme/config/validator');
 
-// Customize Visualizers
-config.visualization.visualizerDescriptors = ['./src/visualizers/Visualizers.json', './src/visualizers/Visualizers.dev.json'];
-
 validateConfig(config);
 module.exports = config;

--- a/config/config.webgme.js
+++ b/config/config.webgme.js
@@ -11,6 +11,7 @@ var config = require('webgme/config/config.default'),
 config.plugin.basePaths.push('src/plugins');
 config.plugin.basePaths.push('node_modules/webgme-simple-nodes/src/plugins');
 config.visualization.layout.basePaths.push('src/layouts');
+config.visualization.decoratorPaths.push('src/decorators');
 config.seedProjects.basePaths.push('src/seeds/CNN-dev');
 config.seedProjects.basePaths.push('src/seeds/Caffe');
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "dependencies": {
     "underscore": "^1.8.3",
-    "webgme": "^1.1.0",
+    "webgme": "webgme/webgme",
     "webgme-simple-nodes": "brollb/webgme-simple-nodes"
   },
   "devDependencies": {

--- a/src/decorators/SVGTemplateDecorator/Core/SVGTemplateDecorator.js
+++ b/src/decorators/SVGTemplateDecorator/Core/SVGTemplateDecorator.js
@@ -1,0 +1,72 @@
+// This contains the core functions for the templating functionality
+define([
+    'js/Constants',
+], function(
+    CONSTANTS
+) {
+    'use strict';
+    
+    var SVGTemplateDecorator = function() {
+        this.attributes = [];
+        this.attributeValues = {};
+        this.attributeFields = {};
+    };
+
+    SVGTemplateDecorator.prototype._collectAttributeFields = function () {
+        var client = this._control._client,
+            nodeObj = client.getNode(this._metaInfo[CONSTANTS.GME_ID]);
+
+        //render GME-ID in the DOM, for debugging
+        this.$el.attr({'data-id': this._metaInfo[CONSTANTS.GME_ID]});
+
+        if (nodeObj) {
+            // Find and populate the attributes
+            var fields = this.$svgContent.find('tspan[data-attribute]'),
+                field,
+                attr,
+                value;
+
+            for (var i = fields.length; i--;) {
+                field = fields[i];
+                attr = field.getAttribute('data-attribute');
+                // Initialize the field list if needed and add the field
+                if (!this.attributeFields[attr]) {
+                    this.attributeFields[attr] = [];
+                }
+                this.attributeFields[attr].push(field);
+            }
+            this.attributes = Object.keys(this.attributeFields);
+        }
+    };
+
+    SVGTemplateDecorator.prototype.update = function () {
+        var client = this._control._client,
+            nodeObj = client.getNode(this._metaInfo[CONSTANTS.GME_ID]),
+            attribute,
+            field,
+            value;
+
+        // Find and populate the attributes
+        for (var i = this.attributes.length; i--;) {
+            attribute = this.attributes[i];
+            value = nodeObj.getAttribute(attribute) || '';
+            if (value !== this.attributeValues[attribute]) {
+                this.attributeValues[attribute] = value;
+                for (var f = this.attributeFields[attribute].length; f--;) {
+                    this.attributeFields[attribute][f].innerHTML = value;
+                }
+            }
+        }
+        // FIXME: Can I re-rasterize the svg to fix the location of the text fields?
+    };
+
+
+    // TODO: Add inline editing for attributes
+    SVGTemplateDecorator.prototype.doSearch = function (searchDesc) {
+        var searchText = searchDesc.toString();
+        // TODO: Add support for searching
+        return false;
+    };
+
+    return SVGTemplateDecorator;
+});

--- a/src/decorators/SVGTemplateDecorator/DiagramDesigner/SVGTemplateDecorator.DiagramDesignerWidget.css
+++ b/src/decorators/SVGTemplateDecorator/DiagramDesigner/SVGTemplateDecorator.DiagramDesignerWidget.css
@@ -1,0 +1,26 @@
+/**
+ * @author brollb / https://github.com/brollb
+ */
+  .svg-template-decorator .connector {
+    background-color: #fefefe;
+    height: 10px;
+    width: 10px;
+    position: absolute;
+    cursor: pointer;
+    border: 1px solid blue;
+    z-index: 10;
+    margin-left: -6px;
+    left: 50%; }
+    .svg-template-decorator .connector:hover {
+      border-color: rgba(82, 168, 236, 0.8);
+      -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
+      -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
+      box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6); }
+    .svg-template-decorator .connector.top {
+      top: -6px; }
+    .svg-template-decorator .connector.bottom {
+      bottom: -6px; }
+
+.selected .svg-template-decorator {
+  border: 1px solid #52a8ec;
+  background-color: #dbeafc; }

--- a/src/decorators/SVGTemplateDecorator/DiagramDesigner/SVGTemplateDecorator.DiagramDesignerWidget.html
+++ b/src/decorators/SVGTemplateDecorator/DiagramDesigner/SVGTemplateDecorator.DiagramDesignerWidget.html
@@ -1,0 +1,3 @@
+<div class="svg-template-decorator">
+    <div class='svg-content'></div>
+</div>

--- a/src/decorators/SVGTemplateDecorator/DiagramDesigner/SVGTemplateDecorator.DiagramDesignerWidget.js
+++ b/src/decorators/SVGTemplateDecorator/DiagramDesigner/SVGTemplateDecorator.DiagramDesignerWidget.js
@@ -1,0 +1,50 @@
+/*globals define, _, $*/
+/*jshint browser: true, camelcase: false*/
+
+/**
+ * @author brollb / https://github.com/brollb
+ */
+
+define([
+    'js/Constants',
+    'decorators/SVGDecorator/DiagramDesigner/SVGDecorator.DiagramDesignerWidget',
+    '../Core/SVGTemplateDecorator',
+    'text!./SVGTemplateDecorator.DiagramDesignerWidget.html',
+    'css!./SVGTemplateDecorator.DiagramDesignerWidget.css'
+], function (
+    CONSTANTS,
+    SVGDecorator,
+    SVGTemplateDecoratorCore,
+    SVGTemplateDecoratorTemplate
+) {
+
+    'use strict';
+
+    var SVGTemplateDecorator,
+        DECORATOR_ID = 'SVGTemplateDecorator';
+
+    SVGTemplateDecorator = function (options) {
+        var opts = _.extend({}, options);
+
+        SVGDecorator.apply(this, [opts]);
+        SVGTemplateDecoratorCore.call(this, opts);
+
+        this.logger.debug('SVGTemplateDecorator ctor');
+    };
+
+    _.extend(SVGTemplateDecorator.prototype, SVGDecorator.prototype,
+        SVGTemplateDecoratorCore.prototype);
+    SVGTemplateDecorator.prototype.DECORATORID = DECORATOR_ID;
+
+    SVGTemplateDecorator.prototype.$DOMBase = $(SVGTemplateDecoratorTemplate);
+
+    SVGTemplateDecorator.prototype.on_addTo = function () {
+        var self = this;
+        //let the parent decorator class do its job first
+        SVGDecorator.prototype.on_addTo.apply(this, arguments);
+        this._collectAttributeFields();
+        this.update();
+    };
+
+    return SVGTemplateDecorator;
+});

--- a/src/decorators/SVGTemplateDecorator/PartBrowser/SVGTemplateDecorator.PartBrowserWidget.css
+++ b/src/decorators/SVGTemplateDecorator/PartBrowser/SVGTemplateDecorator.PartBrowserWidget.css
@@ -1,0 +1,7 @@
+/**
+ * @author brollb / https://github.com/brollb
+ */
+.part-browser .svg-template-decorator .name {
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis; }

--- a/src/decorators/SVGTemplateDecorator/PartBrowser/SVGTemplateDecorator.PartBrowserWidget.js
+++ b/src/decorators/SVGTemplateDecorator/PartBrowser/SVGTemplateDecorator.PartBrowserWidget.js
@@ -1,0 +1,50 @@
+/*globals define, _, DEBUG, $*/
+/*jshint browser: true*/
+
+/**
+ * @author rkereskenyi / https://github.com/rkereskenyi
+ */
+
+
+define([
+    'decorators/SVGDecorator/PartBrowser/SVGDecorator.PartBrowserWidget',
+    '../Core/SVGTemplateDecorator',
+    'text!../DiagramDesigner/SVGTemplateDecorator.DiagramDesignerWidget.html',
+    'css!../DiagramDesigner/SVGTemplateDecorator.DiagramDesignerWidget.css',
+    'css!./SVGTemplateDecorator.PartBrowserWidget.css'
+], function (
+    SVGDecorator,
+    SVGTemplateDecoratorCore,
+    SVGTemplateDecoratorTemplate
+) {
+
+    'use strict';
+
+    var SVGTemplateDecoratorPartBrowserWidget,
+        DECORATOR_ID = 'SVGTemplateDecoratorPartBrowserWidget';
+
+    SVGTemplateDecoratorPartBrowserWidget = function (options) {
+        var opts = _.extend({}, options);
+
+        SVGDecorator.call(this, opts);
+        SVGTemplateDecoratorCore.call(this, opts);
+
+        this.logger.debug('SVGTemplateDecoratorPartBrowserWidget ctor');
+    };
+
+    _.extend(SVGTemplateDecoratorPartBrowserWidget.prototype, SVGDecorator.prototype,
+        SVGTemplateDecoratorCore.prototype);
+
+    SVGTemplateDecoratorPartBrowserWidget.prototype.DECORATORID = DECORATOR_ID;
+    SVGTemplateDecoratorPartBrowserWidget.$DOMBase = $(SVGTemplateDecoratorTemplate);
+
+    
+    SVGTemplateDecoratorPartBrowserWidget.prototype.beforeAppend = function () {
+        this.$el = SVGTemplateDecoratorPartBrowserWidget.$DOMBase.clone();
+        SVGDecorator.prototype.beforeAppend.apply(this, arguments);
+        this._collectAttributeFields();
+        this.update();
+    };
+
+    return SVGTemplateDecoratorPartBrowserWidget;
+});

--- a/src/decorators/SVGTemplateDecorator/SVGTemplateDecorator.js
+++ b/src/decorators/SVGTemplateDecorator/SVGTemplateDecorator.js
@@ -1,0 +1,46 @@
+/*globals define, _*/
+/*jshint browser: true, camelcase: false*/
+
+/**
+ * @author brollb / https://github.com/brollb
+ */
+
+define([
+    'js/Decorators/DecoratorBase',
+    './DiagramDesigner/SVGTemplateDecorator.DiagramDesignerWidget',
+    './PartBrowser/SVGTemplateDecorator.PartBrowserWidget'
+], function (
+    DecoratorBase,
+    SVGTemplateDecoratorDiagramDesignerWidget,
+    SVGTemplateDecoratorPartBrowserWidget
+) {
+
+    'use strict';
+
+    var SVGTemplateDecorator,
+        __parent__ = DecoratorBase,
+        __parent_proto__ = DecoratorBase.prototype,
+        DECORATOR_ID = 'SVGTemplateDecorator';
+
+    SVGTemplateDecorator = function (params) {
+        var opts = _.extend({loggerName: this.DECORATORID}, params);
+
+        __parent__.apply(this, [opts]);
+
+        this.logger.debug('SVGTemplateDecorator ctor');
+    };
+
+    _.extend(SVGTemplateDecorator.prototype, __parent_proto__);
+    SVGTemplateDecorator.prototype.DECORATORID = DECORATOR_ID;
+
+    /*********************** OVERRIDE DecoratorBase MEMBERS **************************/
+
+    SVGTemplateDecorator.prototype.initializeSupportedWidgetMap = function () {
+        this.supportedWidgetMap = {
+            DiagramDesigner: SVGTemplateDecoratorDiagramDesignerWidget,
+            PartBrowser: SVGTemplateDecoratorPartBrowserWidget
+        };
+    };
+
+    return SVGTemplateDecorator;
+});

--- a/src/seeds/Caffe/Caffe.json
+++ b/src/seeds/Caffe/Caffe.json
@@ -114,6 +114,7 @@
     "d7b67be7-a29a-1c42-5d18-98167710b2b7": "2058454590",
     "d7f22c9a-d890-0aff-2001-6a72fc1ef70b": "2000384632",
     "d84a3fc8-5371-d21a-7a20-738d562f01fc": "1828683604",
+    "d868adb1-4397-84ab-d612-0c3b9e3f3c6f": "1050511974",
     "da2d435d-9bfc-00d0-644a-540593bd4053": "1059566835",
     "db3d02a8-5081-de29-c1c3-d0e868feca9d": "220997271",
     "dc1c7d62-e8aa-978a-194e-5d3591bc206c": "1329594813",
@@ -215,6 +216,7 @@
         "ccf73e3e-00a4-cb7f-544c-3d89676aa652": {},
         "d49fb161-5809-0bde-29aa-f2b952b614a3": {},
         "d7f22c9a-d890-0aff-2001-6a72fc1ef70b": {},
+        "d868adb1-4397-84ab-d612-0c3b9e3f3c6f": {},
         "dd210c89-fc91-ed6f-067a-8c6eb97cd323": {},
         "e4cdc631-ef5c-6d1e-ed1b-72a704633e7b": {},
         "eaaa4d9f-c3ad-3531-f520-cff4bbccf647": {},
@@ -298,6 +300,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/defaultLarge.svg",
         "isAbstract": false,
         "position": {
           "x": 173,
@@ -426,6 +429,7 @@
         "base": "de92e114-12a2-3c24-cad6-45da2628a0a2"
       },
       "registry": {
+        "SVGIcon": "Network.svg",
         "isAbstract": false,
         "position": {
           "x": 41,
@@ -485,6 +489,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/softmaxwithloss.svg",
         "isAbstract": false,
         "position": {
           "x": -17,
@@ -566,6 +571,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/lrn.svg",
         "isAbstract": false,
         "position": {
           "x": 33,
@@ -586,6 +592,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/accuracy.svg",
         "isAbstract": false,
         "position": {
           "x": 287,
@@ -709,6 +716,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/fc.svg",
         "isAbstract": false,
         "position": {
           "x": 99,
@@ -780,6 +788,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/euclideanloss.svg",
         "isAbstract": false,
         "position": {
           "x": 243,
@@ -960,6 +969,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/input.svg",
         "isAbstract": false,
         "position": {
           "x": 284,
@@ -980,6 +990,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/euclideanloss.svg",
         "isAbstract": false,
         "position": {
           "x": 123,
@@ -1112,6 +1123,7 @@
         "base": "cd891e7b-e2ea-e929-f6cd-9faf4f1fc045"
       },
       "registry": {
+        "SVGIcon": "Folder2.svg",
         "isAbstract": false,
         "position": {
           "x": 411,
@@ -1812,8 +1824,8 @@
             "guid": "177b17f9-2ae5-ca74-ede9-fcbbe2304aa7",
             "registry": {
               "position": {
-                "x": 485,
-                "y": 247
+                "x": 464,
+                "y": 250
               }
             }
           },
@@ -1832,8 +1844,8 @@
             "guid": "19d2230e-3181-92a7-f014-ac779d07a0bd",
             "registry": {
               "position": {
-                "x": 685,
-                "y": 247
+                "x": 672,
+                "y": 250
               }
             }
           },
@@ -1862,8 +1874,8 @@
             "guid": "379f6898-d91a-9603-e8ab-bf9eadbd750a",
             "registry": {
               "position": {
-                "x": 905,
-                "y": 247
+                "x": 912,
+                "y": 252
               }
             }
           },
@@ -1932,8 +1944,8 @@
             "guid": "762c356b-0b7e-5ba3-f0f7-e823ed72d6eb",
             "registry": {
               "position": {
-                "x": 585,
-                "y": 247
+                "x": 565,
+                "y": 251
               }
             }
           },
@@ -1992,8 +2004,8 @@
             "guid": "ab75c244-4063-f1fc-f3fe-8db6eb543d14",
             "registry": {
               "position": {
-                "x": 555,
-                "y": 740
+                "x": 537,
+                "y": 734
               }
             }
           },
@@ -2222,8 +2234,8 @@
             "guid": "fe95eaff-0a9a-fbe0-92d4-b48ef4bea055",
             "registry": {
               "position": {
-                "x": 805,
-                "y": 247
+                "x": 812,
+                "y": 250
               }
             }
           }
@@ -2323,6 +2335,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/defaultLarge.svg",
         "isAbstract": false,
         "position": {
           "x": 163,
@@ -2745,6 +2758,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/relu.svg",
         "isAbstract": false,
         "position": {
           "x": 253,
@@ -2848,6 +2862,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/defaultLarge.svg",
         "isAbstract": false,
         "position": {
           "x": 53,
@@ -3176,8 +3191,8 @@
       },
       "registry": {
         "position": {
-          "x": 48,
-          "y": 106
+          "x": 51,
+          "y": 157
         }
       },
       "sets": {},
@@ -3222,6 +3237,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/euclideanloss.svg",
         "isAbstract": false,
         "position": {
           "x": 53,
@@ -3299,6 +3315,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/label.svg",
         "isAbstract": false,
         "position": {
           "x": 86,
@@ -3465,6 +3482,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/defaultLarge.svg",
         "isAbstract": false,
         "position": {
           "x": 283,
@@ -3773,6 +3791,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/defaultLarge.svg",
         "isAbstract": false,
         "position": {
           "x": 273,
@@ -3891,6 +3910,8 @@
         "base": "cd891e7b-e2ea-e929-f6cd-9faf4f1fc045"
       },
       "registry": {
+        "SVGIcon": "svgs/default.svg",
+        "decorator": "SVGTemplateDecorator",
         "position": {
           "x": 43,
           "y": 67
@@ -3941,7 +3962,7 @@
         "DisplayFormat": "$name",
         "PortSVGIcon": "",
         "SVGIcon": "",
-        "decorator": "ModelDecorator",
+        "decorator": "SVGDecorator",
         "isAbstract": true,
         "isPort": false,
         "position": {
@@ -3977,6 +3998,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/dropout.svg",
         "isAbstract": false,
         "position": {
           "x": 145,
@@ -4128,6 +4150,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/euclideanloss.svg",
         "isAbstract": false,
         "position": {
           "x": 207,
@@ -4189,6 +4212,24 @@
         "position": {
           "x": 297,
           "y": 221
+        }
+      },
+      "sets": {},
+      "constraints": {}
+    },
+    "d868adb1-4397-84ab-d612-0c3b9e3f3c6f": {
+      "attributes": {},
+      "base": "e465db23-f9df-941b-4a58-2a8f77e67489",
+      "meta": {},
+      "parent": "98742191-1973-92ef-fca7-353ea4f01dc8",
+      "pointers": {
+        "base": "e465db23-f9df-941b-4a58-2a8f77e67489"
+      },
+      "registry": {
+        "SVGIcon": "svgs/sigmoidcrossentropyloss.svg",
+        "position": {
+          "x": 336,
+          "y": 118
         }
       },
       "sets": {},
@@ -4275,6 +4316,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/defaultLarge.svg",
         "isAbstract": false,
         "position": {
           "x": 381,
@@ -4350,6 +4392,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/deconv.svg",
         "isAbstract": false,
         "position": {
           "x": 83,
@@ -4370,6 +4413,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/sigmoidcrossentropyloss.svg",
         "isAbstract": false,
         "position": {
           "x": 313,
@@ -4390,6 +4434,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/flatten.svg",
         "isAbstract": false,
         "position": {
           "x": 181,
@@ -4623,6 +4668,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/conv.svg",
         "isAbstract": false,
         "position": {
           "x": 21,
@@ -4651,6 +4697,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/concat.svg",
         "isAbstract": false,
         "position": {
           "x": 277,
@@ -4768,6 +4815,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/pooling.svg",
         "isAbstract": false,
         "position": {
           "x": 191,
@@ -4807,6 +4855,7 @@
         "base": "ccc0db24-3dba-3694-cb4a-9c41744f2680"
       },
       "registry": {
+        "SVGIcon": "svgs/softmax.svg",
         "isAbstract": false,
         "position": {
           "x": 107,

--- a/src/svgs/accuracy.svg
+++ b/src/svgs/accuracy.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="85"
+   height="33"
+   viewBox="0 0 85 33"
+   id="svg3511"
+   version="1.1"
+   sodipodi:docname="conv.svg">
+  <path
+    d="M 0 9.44 M 23.61 0 L 60.60 0 M 85 9.44 L 85 23.61 M 60.60 33 L 23.61 33 M 0 23.61 L 0 9.44"
+    style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:3;stroke-opacity:1" />
+  <path
+    d="M 0 9.44 L 23.61 0 M 60.60 0 L 85 9.44 M 85 23.61 L 60.60 33 M 23.61 33 L 0 23.61 M 0 9.44"
+    style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:1.5;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="42.5"
+     y="20"
+     id="text4871"
+     text-anchor="middle"
+     sodipodi:linespacing="125%">accuracy</text>
+    <line id='ca_1' class='connection-area' x1="42.5" y1="0" x2="42.5" y2="0"></line>
+    <line id='ca_2' class='connection-area' x1="42.5" y1="33" x2="42.5" y2="33"></line>
+</svg>

--- a/src/svgs/concat.svg
+++ b/src/svgs/concat.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="70"
+   height="28"
+   viewBox="0 0 70 28"
+   id="svg3511"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="conv.svg">
+  <rect
+     x="0"
+     y="0"
+     width="70"
+     height="28"
+     id="path4329"
+     inkscape:connector-curvature="0"
+     style="fill:#9e9e9e;fill-opacity:1;stroke:#9e9e9e;stroke-width:0.70582372;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#dbedeb;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="34"
+     y="18.151272"
+     id="text4871"
+     sodipodi:linespacing="125%">concat</text>
+    <line id='ca_1' class='connection-area' data-angle="135" x1="30" y1="0" x2="30" y2="0"></line>
+    <line id='ca_2' class='connection-area' data-angle="135" x1="30" y1="29" x2="30" y2="29"></line>
+</svg>

--- a/src/svgs/conv.svg
+++ b/src/svgs/conv.svg
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="93.93042"
+   height="49.057842"
+   viewBox="0 0 90 40"
+   id="svg3511"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="conv.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1598"
+     inkscape:window-height="877"
+     id="namedview16"
+     showgrid="false"
+     inkscape:zoom="6.6831361"
+     inkscape:cx="37.441153"
+     inkscape:cy="13.369002"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3511" />
+  <rect
+     x="0"
+     y="0"
+     width="90"
+     height="40"
+     id="path4329"
+     inkscape:connector-curvature="0"
+     style="fill:#4285f4;fill-opacity:1;stroke:#4285f4;stroke-width:0.70582372;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#fbedeb;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="45"
+     y="16.151272"
+     id="text4871"
+     sodipodi:linespacing="125%"><tspan
+       id="tspan5">Conv</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:12px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#fbedeb;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="16"
+     y="31.924364"
+     id="text4875"
+     sodipodi:linespacing="125%"><tspan
+       data-attribute="kernel_size"
+       id="tspan8">5</tspan><tspan
+       id="tspan10">x</tspan><tspan
+       data-attribute="kernel_size"
+       id="tspan12">0</tspan><tspan
+       id="tspan14"> + </tspan><tspan
+       data-attribute="stride"
+       >1</tspan><tspan
+       >(S)</tspan></text>
+
+    <line id='ca_1' class='connection-area' data-angle="135" x1="20" y1="0" x2="80" y2="0"></line>
+    <line id='ca_2' class='connection-area' data-angle="135" x1="20" y1="45" x2="80" y2="45"></line>
+</svg>

--- a/src/svgs/deconv.svg
+++ b/src/svgs/deconv.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="110"
+   height="28"
+   viewBox="0 0 110 28"
+   id="svg3511"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="conv.svg">
+  <rect
+     x="0"
+     y="0"
+     width="110"
+     height="28"
+     id="path4329"
+     inkscape:connector-curvature="0"
+     style="fill:#4285f4;fill-opacity:1;stroke:#4285f4;stroke-width:0.70582372;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#dbedeb;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="54"
+     y="18.151272"
+     id="text4871"
+     sodipodi:linespacing="125%"><tspan data-attribute="name">name</tspan></text>
+    <line id='ca_1' class='connection-area' data-angle="135" x1="30" y1="0" x2="78" y2="0"></line>
+    <line id='ca_2' class='connection-area' data-angle="135" x1="30" y1="29" x2="78" y2="29"></line>
+</svg>

--- a/src/svgs/default.svg
+++ b/src/svgs/default.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="70"
+   height="28"
+   viewBox="0 0 70 28"
+   id="svg3511"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="conv.svg">
+  <rect
+     x="0"
+     y="0"
+     width="70"
+     height="28"
+     id="path4329"
+     inkscape:connector-curvature="0"
+     style="fill:#9e9e9e;fill-opacity:1;stroke:#9e9e9e;stroke-width:0.70582372;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#dbedeb;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="34"
+     y="18.151272"
+     id="text4871"
+     sodipodi:linespacing="125%"><tspan data-attribute="name">name</tspan></text>
+    <line id='ca_1' class='connection-area' data-angle="135" x1="30" y1="0" x2="30" y2="0"></line>
+    <line id='ca_2' class='connection-area' data-angle="135" x1="30" y1="29" x2="30" y2="29"></line>
+</svg>

--- a/src/svgs/defaultLarge.svg
+++ b/src/svgs/defaultLarge.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="100"
+   height="28"
+   viewBox="0 0 100 28"
+   id="svg3511"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="conv.svg">
+  <rect
+     x="0"
+     y="0"
+     width="100"
+     height="28"
+     id="path4329"
+     inkscape:connector-curvature="0"
+     style="fill:#9e9e9e;fill-opacity:1;stroke:#9e9e9e;stroke-width:0.70582372;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#dbedeb;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="49"
+     y="18.151272"
+     id="text4871"
+     sodipodi:linespacing="125%"><tspan data-attribute="name">name</tspan></text>
+    <line id='ca_1' class='connection-area' data-angle="135" x1="50" y1="0" x2="50" y2="0"></line>
+    <line id='ca_2' class='connection-area' data-angle="135" x1="50" y1="29" x2="50" y2="29"></line>
+</svg>

--- a/src/svgs/depthconcat.svg
+++ b/src/svgs/depthconcat.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="101.6mm"
+   height="28.154001mm"
+   viewBox="0 0 359.99999 99.758272"
+   id="svg3511"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="depthconcat.svg">
+  <defs
+     id="defs3513" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.97207031"
+     inkscape:cx="146.78571"
+     inkscape:cy="-139.20183"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1598"
+     inkscape:window-height="877"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata3516">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-56.416013,-293.4021)">
+    <path
+       d="m 56.680245,343.28123 0,-49.6149 179.735765,0 179.73577,0 0,49.6149 0,49.61491 -179.73577,0 -179.735765,0 0,-49.61491 z"
+       id="path4329"
+       inkscape:connector-curvature="0"
+       style="fill:#4caf50;fill-opacity:1;stroke:#4caf50;stroke-width:0.52846396;stroke-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="237.4498"
+       y="355.91049"
+       id="text4871"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4873"
+         x="237.4498"
+         y="355.91049">DepthConcat</tspan></text>
+  </g>
+</svg>

--- a/src/svgs/dropout.svg
+++ b/src/svgs/dropout.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="70"
+   height="28"
+   viewBox="0 0 70 28"
+   id="svg3511"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="conv.svg">
+  <rect
+     x="0"
+     y="0"
+     width="70"
+     height="28"
+     id="path4329"
+     inkscape:connector-curvature="0"
+     style="fill:#f4b400;fill-opacity:1;stroke:#f4b400;stroke-width:0.70582372;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#dbedeb;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="34"
+     y="18.151272"
+     id="text4871"
+     sodipodi:linespacing="125%">dropout</text>
+    <line id='ca_1' class='connection-area' data-angle="135" x1="30" y1="0" x2="30" y2="0"></line>
+    <line id='ca_2' class='connection-area' data-angle="135" x1="30" y1="29" x2="30" y2="29"></line>
+</svg>

--- a/src/svgs/euclideanloss.svg
+++ b/src/svgs/euclideanloss.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="115"
+   height="33"
+   viewBox="0 0 115 33"
+   id="svg3511"
+   version="1.1"
+   sodipodi:docname="conv.svg">
+  <path
+    d="M 0 9.44 M 23.61 0 L 90.60 0 M 115 9.44 L 115 23.61 M 90.60 33 L 23.61 33 M 0 23.61 L 0 9.44"
+    style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:3;stroke-opacity:1" />
+  <path
+    d="M 0 9.44 L 23.61 0 M 90.60 0 L 115 9.44 M 115 23.61 L 90.60 33 M 23.61 33 L 0 23.61 M 0 9.44"
+    style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:1.5;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="57.5"
+     y="20"
+     id="text4871"
+     text-anchor="middle"
+     sodipodi:linespacing="125%"><tspan data-attribute="name">name</tspan></text>
+    <line id='ca_1' class='connection-area' x1="42.5" y1="0" x2="42.5" y2="0"></line>
+    <line id='ca_2' class='connection-area' x1="42.5" y1="33" x2="42.5" y2="33"></line>
+</svg>

--- a/src/svgs/fc.svg
+++ b/src/svgs/fc.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="50"
+   height="28"
+   viewBox="0 0 50 28"
+   id="svg3511"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="conv.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1598"
+     inkscape:window-height="877"
+     id="namedview16"
+     showgrid="false"
+     inkscape:zoom="6.6831361"
+     inkscape:cx="37.441153"
+     inkscape:cy="13.369002"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3511" />
+  <rect
+     x="0"
+     y="0"
+     width="50"
+     height="28"
+     id="path4329"
+     inkscape:connector-curvature="0"
+     style="fill:#4285f4;fill-opacity:1;stroke:#4285f4;stroke-width:0.70582372;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#dbedeb;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="25"
+     y="18.151272"
+     id="text4871"
+     text-anchor="middle"
+     sodipodi:linespacing="125%">FC</text>
+    <line id='ca_1' class='connection-area' x1="25" y1="0" x2="25" y2="0"></line>
+    <line id='ca_2' class='connection-area' x1="25" y1="29" x2="25" y2="29"></line>
+</svg>

--- a/src/svgs/flatten.svg
+++ b/src/svgs/flatten.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="70"
+   height="28"
+   viewBox="0 0 70 28"
+   id="svg3511"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="conv.svg">
+  <rect
+     x="0"
+     y="0"
+     width="70"
+     height="28"
+     id="path4329"
+     inkscape:connector-curvature="0"
+     style="fill:#9e9e9e;fill-opacity:1;stroke:#9e9e9e;stroke-width:0.70582372;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#dbedeb;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="34"
+     y="18.151272"
+     id="text4871"
+     sodipodi:linespacing="125%">flatten</text>
+    <line id='ca_1' class='connection-area' data-angle="135" x1="30" y1="0" x2="30" y2="0"></line>
+    <line id='ca_2' class='connection-area' data-angle="135" x1="30" y1="29" x2="30" y2="29"></line>
+</svg>

--- a/src/svgs/input.svg
+++ b/src/svgs/input.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="85"
+   height="33"
+   viewBox="0 0 85 33"
+   id="svg3511"
+   version="1.1"
+   sodipodi:docname="conv.svg">
+  <path
+    d="M 0 9.44 M 23.61 0 L 60.60 0 M 85 9.44 L 85 23.61 M 60.60 33 L 23.61 33 M 0 23.61 L 0 9.44"
+    style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:3;stroke-opacity:1" />
+  <path
+    d="M 0 9.44 L 23.61 0 M 60.60 0 L 85 9.44 M 85 23.61 L 60.60 33 M 23.61 33 L 0 23.61 M 0 9.44"
+    style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:1.5;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="42.5"
+     y="20"
+     id="text4871"
+     text-anchor="middle"
+     sodipodi:linespacing="125%">input</text>
+    <line id='ca_1' class='connection-area' x1="42.5" y1="0" x2="42.5" y2="0"></line>
+    <line id='ca_2' class='connection-area' x1="42.5" y1="33" x2="42.5" y2="33"></line>
+</svg>

--- a/src/svgs/label.svg
+++ b/src/svgs/label.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="60"
+   height="28"
+   viewBox="0 0 60 28"
+   id="svg3511"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="conv.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1598"
+     inkscape:window-height="877"
+     id="namedview16"
+     showgrid="false"
+     inkscape:zoom="6.6831361"
+     inkscape:cx="37.441153"
+     inkscape:cy="13.369002"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3511" />
+  <rect
+     x="0"
+     y="0"
+     width="60"
+     height="28"
+     id="path4329"
+     inkscape:connector-curvature="0"
+     style="fill:#f4b400;fill-opacity:1;stroke:#f4b400;stroke-width:0.70582372;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#dbedeb;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="29"
+     y="18.151272"
+     id="text4871"
+     sodipodi:linespacing="125%">labels</text>
+    <line id='ca_1' class='connection-area' data-angle="135" x1="30" y1="0" x2="30" y2="0"></line>
+    <line id='ca_2' class='connection-area' data-angle="135" x1="30" y1="29" x2="30" y2="29"></line>
+</svg>

--- a/src/svgs/lrn.svg
+++ b/src/svgs/lrn.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="60"
+   height="28"
+   viewBox="0 0 60 28"
+   id="svg3511"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="conv.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1598"
+     inkscape:window-height="877"
+     id="namedview16"
+     showgrid="false"
+     inkscape:zoom="6.6831361"
+     inkscape:cx="37.441153"
+     inkscape:cy="13.369002"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3511" />
+  <rect
+     x="0"
+     y="0"
+     width="60"
+     height="28"
+     id="path4329"
+     inkscape:connector-curvature="0"
+     style="fill:#0f9d58;fill-opacity:1;stroke:#0f9d58;stroke-width:0.70582372;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#dbedeb;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="29"
+     y="18.151272"
+     id="text4871"
+     sodipodi:linespacing="125%">LRN</text>
+    <line id='ca_1' class='connection-area' data-angle="135" x1="30" y1="0" x2="30" y2="0"></line>
+    <line id='ca_2' class='connection-area' data-angle="135" x1="30" y1="29" x2="30" y2="29"></line>
+</svg>

--- a/src/svgs/pooling.svg
+++ b/src/svgs/pooling.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="93.93042"
+   height="49.057842"
+   viewBox="0 0 90 40"
+   id="svg3511"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="conv.svg">
+  <rect
+     x="0"
+     y="0"
+     width="90"
+     height="40"
+     id="path4329"
+     inkscape:connector-curvature="0"
+     style="fill:#db4437;fill-opacity:1;stroke:#db4437;stroke-width:0.70582372;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#dbedeb;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="41"
+     y="16.151272"
+     id="text4871"
+     sodipodi:linespacing="125%">
+    <tspan
+       data-attribute="pool"
+       id="tspan5">MAX</tspan><tspan
+       id="tspan5"> Pool</tspan>
+  </text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:12px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#dbedeb;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="16"
+     y="31.924364"
+     id="text4875"
+     sodipodi:linespacing="125%"><tspan
+       data-attribute="kernel_size"
+       id="tspan8">5</tspan><tspan
+       id="tspan10">x</tspan><tspan
+       data-attribute="kernel_size"
+       id="tspan12">5</tspan><tspan
+       id="tspan14"> + </tspan><tspan
+       data-attribute="stride"
+       >1</tspan><tspan
+       >(S)</tspan></text>
+    <line id='ca_1' class='connection-area' data-angle="135" x1="20" y1="0" x2="80" y2="0"></line>
+    <line id='ca_2' class='connection-area' data-angle="135" x1="20" y1="45" x2="80" y2="45"></line>
+</svg>

--- a/src/svgs/prelu.svg
+++ b/src/svgs/prelu.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="70"
+   height="28"
+   viewBox="0 0 70 28"
+   id="svg3511"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="conv.svg">
+  <rect
+     x="0"
+     y="0"
+     width="70"
+     height="28"
+     id="path4329"
+     inkscape:connector-curvature="0"
+     style="fill:#0f9d58;fill-opacity:1;stroke:#0f9d58;stroke-width:0.70582372;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#dbedeb;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="34"
+     y="18.151272"
+     id="text4871"
+     sodipodi:linespacing="125%"><tspan data-attribute="name">name</tspan></text>
+    <line id='ca_1' class='connection-area' data-angle="135" x1="30" y1="0" x2="30" y2="0"></line>
+    <line id='ca_2' class='connection-area' data-angle="135" x1="30" y1="29" x2="30" y2="29"></line>
+</svg>

--- a/src/svgs/relu.svg
+++ b/src/svgs/relu.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="60"
+   height="28"
+   viewBox="0 0 60 28"
+   id="svg3511"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="conv.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1598"
+     inkscape:window-height="877"
+     id="namedview16"
+     showgrid="false"
+     inkscape:zoom="6.6831361"
+     inkscape:cx="37.441153"
+     inkscape:cy="13.369002"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3511" />
+  <rect
+     x="0"
+     y="0"
+     width="60"
+     height="28"
+     id="path4329"
+     inkscape:connector-curvature="0"
+     style="fill:#0f9d58;fill-opacity:1;stroke:#0f9d58;stroke-width:0.70582372;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#dbedeb;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="29"
+     y="18.151272"
+     id="text4871"
+     sodipodi:linespacing="125%">ReLU</text>
+    <line id='ca_1' class='connection-area' data-angle="135" x1="30" y1="0" x2="30" y2="0"></line>
+    <line id='ca_2' class='connection-area' data-angle="135" x1="30" y1="29" x2="30" y2="29"></line>
+</svg>

--- a/src/svgs/sigmoidcrossentropyloss.svg
+++ b/src/svgs/sigmoidcrossentropyloss.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="145"
+   height="48"
+   viewBox="0 0 145 48"
+   id="svg3511"
+   version="1.1"
+   sodipodi:docname="conv.svg">
+  <path
+    d="M 0 9.44 M 25 0 L 120.60 0 M 145 9.44 L 145 38.61 M 120.60 48 L 25 48 M 0 38.61 L 0 9.44"
+    style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:3;stroke-opacity:1" />
+  <path
+    d="M 0 9.44 L 25 0 M 120.60 0 L 145 9.44 M 145 38.61 L 120.60 48 M 25 48 L 0 38.61 M 0 9.44"
+    style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:1.5;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="72.5"
+     y="20"
+     id="text4871"
+     text-anchor="middle"
+     sodipodi:linespacing="125%">sigmoid cross</text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="72.5"
+     y="35"
+     id="text4871"
+     text-anchor="middle"
+     sodipodi:linespacing="125%">entropy loss</text>
+    <line id='ca_1' class='connection-area' x1="70" y1="0" x2="75" y2="0"></line>
+    <line id='ca_2' class='connection-area' x1="70" y1="48" x2="75" y2="48"></line>
+</svg>

--- a/src/svgs/softmax.svg
+++ b/src/svgs/softmax.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="85"
+   height="33"
+   viewBox="0 0 85 33"
+   id="svg3511"
+   version="1.1"
+   sodipodi:docname="conv.svg">
+  <path
+    d="M 0 9.44 M 23.61 0 L 60.60 0 M 85 9.44 L 85 23.61 M 60.60 33 L 23.61 33 M 0 23.61 L 0 9.44"
+    style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:3;stroke-opacity:1" />
+  <path
+    d="M 0 9.44 L 23.61 0 M 60.60 0 L 85 9.44 M 85 23.61 L 60.60 33 M 23.61 33 L 0 23.61 M 0 9.44"
+    style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:1.5;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="42.5"
+     y="20"
+     id="text4871"
+     text-anchor="middle"
+     sodipodi:linespacing="125%">softmax</text>
+    <line id='ca_1' class='connection-area' x1="42.5" y1="0" x2="42.5" y2="0"></line>
+    <line id='ca_2' class='connection-area' x1="42.5" y1="33" x2="42.5" y2="33"></line>
+</svg>

--- a/src/svgs/softmaxactivation.svg
+++ b/src/svgs/softmaxactivation.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="122.21351mm"
+   height="28.154003mm"
+   viewBox="0 0 433.03999 99.758279"
+   id="svg3511"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="softmaxactivation.svg">
+  <defs
+     id="defs3513" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.97207031"
+     inkscape:cx="161.18796"
+     inkscape:cy="-139.20183"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1598"
+     inkscape:window-height="877"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata3516">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-56.416013,-293.4021)">
+    <path
+       d="m 56.705757,343.28123 0,-49.58939 216.230243,0 216.23025,0 0,49.58939 0,49.5894 -216.23025,0 -216.230243,0 0,-49.5894 z"
+       id="path4329"
+       inkscape:connector-curvature="0"
+       style="fill:#ffeb3b;fill-opacity:1;stroke:#ffeb3b;stroke-width:0.57948828;stroke-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="271.4498"
+       y="355.91049"
+       id="text4871"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4873"
+         x="271.4498"
+         y="355.91049">SoftmaxActivation</tspan></text>
+  </g>
+</svg>

--- a/src/svgs/softmaxwithloss.svg
+++ b/src/svgs/softmaxwithloss.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="115"
+   height="33"
+   viewBox="0 0 115 33"
+   id="svg3511"
+   version="1.1"
+   sodipodi:docname="conv.svg">
+  <path
+    d="M 0 9.44 M 23.61 0 L 90.60 0 M 115 9.44 L 115 23.61 M 90.60 33 L 23.61 33 M 0 23.61 L 0 9.44"
+    style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:3;stroke-opacity:1" />
+  <path
+    d="M 0 9.44 L 23.61 0 M 90.60 0 L 115 9.44 M 115 23.61 L 90.60 33 M 23.61 33 L 0 23.61 M 0 9.44"
+    style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:1.5;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="57.5"
+     y="20"
+     id="text4871"
+     text-anchor="middle"
+     sodipodi:linespacing="125%">softmax w/ loss</text>
+    <line id='ca_1' class='connection-area' x1="42.5" y1="0" x2="42.5" y2="0"></line>
+    <line id='ca_2' class='connection-area' x1="42.5" y1="33" x2="42.5" y2="33"></line>
+</svg>

--- a/src/visualizers/Visualizers.dev.json
+++ b/src/visualizers/Visualizers.dev.json
@@ -1,6 +1,0 @@
-[
-    {"id": "METAAspect",
-        "title": "Meta",
-        "panel": "js/Panels/MetaEditor/MetaEditorPanel",
-        "DEBUG_ONLY": false}
-]

--- a/src/visualizers/Visualizers.json
+++ b/src/visualizers/Visualizers.json
@@ -4,5 +4,11 @@
     "title": "Network Editor",
     "panel": "panels/CNNViz/CNNVizPanel",
     "DEBUG_ONLY": false
+  },
+  {
+    "id": "METAAspect",
+    "title": "Meta",
+    "panel": "js/Panels/MetaEditor/MetaEditorPanel",
+    "DEBUG_ONLY": false
   }
 ]

--- a/webgme-setup.json
+++ b/webgme-setup.json
@@ -44,7 +44,11 @@
         "src": "src/layouts/MinimalLayout"
       }
     },
-    "decorators": {},
+    "decorators": {
+      "SVGTemplateDecorator": {
+        "src": "src/decorators/SVGTemplateDecorator"
+      }
+    },
     "addons": {}
   },
   "dependencies": {


### PR DESCRIPTION
Added template support for diagram designer. WIP #62

WIP #62 Added svgs

Added svgs for #62

These are a good starting point but they have a lot of room for
improvement. For now, blue are main layer types, octogons are loss
layers, and grey are utility. Labels and dropout layers are yellow
and input layers are also octogorns.